### PR TITLE
Require less loose versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pyyaml
-jinja2
-boto
-botocore
-tabulate
+PyYAML>=3.11
+Jinja2>=2.7.3
+boto>=2.38.0
+botocore>=1.1.1
+tabulate>=0.7.5


### PR DESCRIPTION
This partially fixes #2. We need to ship a single static binary instead.
