### PR TITLE
Updated get_region_name function which wasn't previously working

### DIFF
--- a/bin/stacks
+++ b/bin/stacks
@@ -92,7 +92,7 @@ def get_region_name(profile, config_file=AWS_CONFIG_FILE):
     '''Return region name from AWS config file'''
     try:
         c = botocore.config.load_config(config_file)
-        r = c.get(profile, {}).get('region', DEFAULT_REGION)
+        r = c.get("profiles",{}).get(profile, {}).get('region', DEFAULT_REGION)
         return r
     except:
         raise RuntimeError('Failed loading config {}'.format(config_file))


### PR DESCRIPTION
stacks wasn't picking up the region from the profile previously, which it should now be able to do
