### PR TITLE
Templates bucket prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,14 @@ Templates do not enforce stack naming convention, but a desired convention is
 to prefix stack names with env name.
 
 CloudFormation API has a template size limit. Instead of submiting templates
-over the API, we first upload them to S3 and then provide an https url. For
-that to work you must have an S3 bucket created and specified in `config.yaml`,
-either in `common` section or per env. Configuration key name is
-`templates_bucket_name`.
+over the API, we first upload them to S3 and then provide an https url. 
+
+ASG templates S3 bucket can be specified in config (key name: `templates_bucket_name`), 
+either in `common` section or per env.
+If `templates_bucket_name` is not present in configuration, bucket name will be constructed automatically 
+as `{env}-stacks-{region}` e.g. `dev-stacks-us-east-1`. You may also specify a custom prefix 
+(config key: `templates_bucket_name_prefix`) to construct the following bucket name: 
+`{prefix}-{env}-stacks-{region}` e.g. `myprefix-dev-stacks-eu-east-1`.
 
 ## Usage
 

--- a/stacks/template.py
+++ b/stacks/template.py
@@ -35,7 +35,11 @@ def gen_template(template, config, pretty=False):
 
 def upload_template(conn, config, tpl, name):
     '''Uploads a template to S3 bucket and returns S3 key url'''
-    bn = config.get('templates_bucket_name', '{}-stacks-{}'.format(config['env'], config['region']))
+
+    bucket_prefix = config.get('templates_bucket_name_prefix')
+    default_bucket_name = '{}-stacks-{}'.format(config['env'], config['region'])
+
+    bn = config.get('templates_bucket_name', '-'.join(filter(None, (bucket_prefix, default_bucket_name))))
 
     try:
         b = config['s3_conn'].get_bucket(bn)


### PR DESCRIPTION
- Updates README describing templates bucket specification. 
- Adds support for optional `templates_bucket_name_prefix` config key. This allows to alter auto-generated bucket names with custom prefix.
