### PR TITLE
Add get_stack_resource()

### DIFF
--- a/stacks/aws.py
+++ b/stacks/aws.py
@@ -76,3 +76,14 @@ def get_stack_tag(conn, name, tag):
         raise RuntimeError('{} stack not found'.format(name))
     tags = [s.tags for s in result][0]
     return tags.get(tag, '')
+
+
+@throttling_retry
+def get_stack_resource(conn, stack_name, logical_id):
+    '''Return a physical_resource_id given its logical_id'''
+    resources = conn.describe_stack_resources(stack_name_or_id=stack_name)
+    for r in resources:
+        # TODO: would be nice to check for resource_status
+        if r.logical_resource_id == logical_id:
+            return r.physical_resource_id
+    return None

--- a/stacks/main.py
+++ b/stacks/main.py
@@ -87,6 +87,7 @@ def main():
     config['get_vpc_id'] = aws.get_vpc_id
     config['get_zone_id'] = aws.get_zone_id
     config['get_stack_output'] = aws.get_stack_output
+    config['get_stack_resource'] = aws.get_stack_resource
 
     if args.subcommand == 'resources':
         output = cf.stack_resources(cf_conn, args.name)


### PR DESCRIPTION
It gets a `physical_resource_id` given its `logical_resource_id`. This
should be a preferred way of cross-stack referencing of resources.

`get_stack_output()` will still work and can be used for getting some
state data from a different stack.
