### PR TITLE
config: print the value only

### DIFF
--- a/stacks/config.py
+++ b/stacks/config.py
@@ -105,7 +105,7 @@ def validate_properties(props_arg):
 def print_config(config, property_name=None):
     if property_name:
         if config.get(property_name):
-            print('{}={}'.format(property_name, config[property_name]))
+            print(config[property_name])
         return
 
     for k, v in config.items():


### PR DESCRIPTION
It does not make sense to print key=value given key name is provided
