### PR TITLE
Disable py35 tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
     - python: 3.4
       env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.4
       env: TOXENV=py34-linux-package
     - python: 3.4

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34, py35, py34-package, py35-package, docs
+envlist = py34, py34-linux-package, docs
 
 [testenv]
 setenv =
@@ -26,6 +26,7 @@ deps =
 commands = py.test
 
 [testenv:py34-linux-package]
+basepython = python3.4
 deps =
     pex
     wheel


### PR DESCRIPTION
PyYAML seems to be broken on python 3.5.
