### PR TITLE
FIX: AttributeError: module botocore.config' has no attribute 'load_config'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
     'PyYAML>=3.11',
     'Jinja2>=2.7.3',
     'boto>=2.38.0',
-    'botocore>=1.1.1',
+    'botocore>=1.1.1,<=1.4.0',
     'tabulate>=0.7.5',
     'setuptools',
 ]


### PR DESCRIPTION
botocore.config.load_config() is removed in botocore 1.4.1<=

See: https://github.com/boto/botocore/commit/730af686e02ad7d78c4f907185fa639fa8a11874
