### PR TITLE
Support CloudFormation YAML tags (#101)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open(os.path.join(base_dir, 'stacks', '__about__.py')) as f:
     exec(f.read(), about)
 
 install_requires = [
+    'awscli>=1.11.130',
     'configargparse>=0.9.3',
     'PyYAML>=3.11',
     'Jinja2>=2.7.3',

--- a/stacks/cf.py
+++ b/stacks/cf.py
@@ -21,6 +21,8 @@ from boto.exception import BotoServerError
 from operator import attrgetter
 from datetime import datetime
 
+from awscli.customizations.cloudformation.yamlhelper import intrinsics_multi_constructor
+
 from stacks.aws import get_stack_tag
 from stacks.aws import throttling_retry
 from stacks.states import FAILED_STACK_STATES, COMPLETE_STACK_STATES, ROLLBACK_STACK_STATES, IN_PROGRESS_STACK_STATES
@@ -38,7 +40,8 @@ def gen_template(tpl_file, config):
     tpl = env.get_template(tpl_fname)
     rendered = tpl.render(config)
     try:
-        docs = list(yaml.load_all(rendered))
+        yaml.SafeLoader.add_multi_constructor("!", intrinsics_multi_constructor)
+        docs = list(yaml.safe_load_all(rendered))
     except yaml.parser.ParserError as err:
         print(err)
         sys.exit(1)

--- a/tests/fixtures/valid_template.yaml
+++ b/tests/fixtures/valid_template.yaml
@@ -7,6 +7,10 @@ metadata:
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Test Stack
+Parameters:
+  Foo:
+    Type: String
+    Default: Bar
 Resources:
   VPC:
     Type: AWS::EC2::VPC
@@ -19,3 +23,15 @@ Resources:
           Value: {{ env }}-test-vpc
         - Key: Env
           Value: {{ env }}
+Outputs:
+  Foo:
+    Description: 'Just to test reference and substitution'
+    Value: !Ref Foo
+    Export:
+      Name: !Sub ${AWS::StackName}-Foo
+  VPCCidrBlock:
+    Description: 'Just to test attribute selection'
+    Value: !GetAtt VPC.CidrBlock
+    Export:
+      Name: !Sub ${AWS::StackName}-VPCCidrBlock
+

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -1,6 +1,6 @@
 import unittest
 import boto
-from moto import mock_cloudformation
+from moto import mock_cloudformation_deprecated
 
 from stacks import cf
 
@@ -31,7 +31,7 @@ class TestTemplate(unittest.TestCase):
         self.assertEqual(err.exception.code, 1)
 
 
-@mock_cloudformation
+@mock_cloudformation_deprecated
 class TestStackActions(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Imported CloudFormations own intrinsics_multi_constructor to support full CloudFormation syntax. This means adding `awscli` as an additional dependency but I would expect people using stacks have it installed anyway.