### PR TITLE
Fix broken dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(base_dir, 'stacks', '__about__.py')) as f:
 install_requires = [
     'awscli>=1.11.130',
     'configargparse>=0.9.3',
-    'PyYAML>=3.11',
+    'PyYAML<=3.13,>=3.10',
     'Jinja2>=2.7.3',
     'boto>=2.40.0',
     'tabulate>=0.7.5',


### PR DESCRIPTION
`awscli` requires PyYAML<=3.13,>=3.10 to be installed, otherwise fails:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/lauris/git/stacks/venv/bin/stacks", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/home/lauris/git/stacks/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3105, in <module>
    @_call_aside
  File "/home/lauris/git/stacks/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3089, in _call_aside
    f(*args, **kwargs)
  File "/home/lauris/git/stacks/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3118, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/home/lauris/git/stacks/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 580, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/home/lauris/git/stacks/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 593, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/home/lauris/git/stacks/venv/lib/python3.6/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (PyYAML 4.2b4 (/home/lauris/git/stacks/venv/lib/python3.6/site-packages/PyYAML-4.2b4-py3.6-linux-x86_64.egg), Requirement.parse('PyYAML<=3.13,>=3.10'), {'awscli'})