### PR TITLE
pin test dep versions and imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ checkout will affect the global `stacks` command.
 
 ```
 $ git clone https://github.com/cfstacks/stacks.git && cd stacks
-$ mkvirtualenv --python=python3 stacks
+$ mkvirtualenv --python=python3 venv
+$ source ./venv/bin/activate
+$ pip install -r requirements.txt
 $ pip install -e .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Jinja2>=2.7.3
 boto>=2.40.0
 tabulate>=0.7.5
 setuptools
-moto>=2.0,<3.0
+moto[all]>=2.0,<3.0
 pytz
 tzlocal
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Jinja2>=2.7.3
 boto>=2.40.0
 tabulate>=0.7.5
 setuptools
+moto>=2.0,<3.0
 pytz
 tzlocal
-moto
+pytest

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -1,6 +1,7 @@
 import unittest
 
-import boto
+from boto import cloudformation, s3
+
 from moto import mock_cloudformation_deprecated
 
 from stacks import cf
@@ -50,8 +51,8 @@ class TestStackActions(unittest.TestCase):
             'custom_tag': 'custom-tag-value',
             'region': 'us-east-1',
         }
-        self.config['cf_conn'] = boto.cloudformation.connect_to_region(self.config['region'])
-        self.config['s3_conn'] = boto.s3.connect_to_region(self.config['region'])
+        self.config['cf_conn'] = cloudformation.connect_to_region(self.config['region'])
+        self.config['s3_conn'] = s3.connect_to_region(self.config['region'])
 
     def test_create_stack(self):
         stack_name = None


### PR DESCRIPTION
As part of adding a feature PR I had some problems getting started. So I have made a PR to try and address this

- looks like this project's tests do not work with moto 3 (I get import failed errors when trying)
- One of the tests seems to import tests in a way that is not compatible with the current version of boto (I have fixed the imports)
- Have fixed up the README to include the steps I made